### PR TITLE
Allow for production build

### DIFF
--- a/index.js
+++ b/index.js
@@ -49,7 +49,10 @@ function createRewireLess(lessLoaderOptions = {}) {
       // Get a copy of the CSS module loader
       getLoader(
         config.module.rules,
-        rule => String(rule.test) === String(/\.module\.css$/),
+        rule =>
+          String(rule.test) === String(/\.module\.css$/) ||
+          (String(rule.test) === String(/\.css$/) &&
+            String(rule.exclude) !== String(/\.module\.css$/)),
       ),
     );
 


### PR DESCRIPTION
The rules in production are slightly different for css modules:
```
     { test: /\.css$/, exclude: /\.module\.css$/, loader: [Array] },
     { test: /\.css$/, loader: [Array] },
```

In the dev environment, this is what is passed:
```
     { test: /\.css$/, exclude: /\.module\.css$/, use: [Array] },
     { test: /\.module\.css$/, use: [Array] },
```